### PR TITLE
feat: add unit training

### DIFF
--- a/server/ui/app.ts
+++ b/server/ui/app.ts
@@ -7,6 +7,7 @@ import { applyThemeFromStorage } from "./theme"
 import { refreshUser, getUser } from "./auth"
 import { loadResourceRates } from "./state"
 import { buildingPage } from "./building"
+import { unitListPage } from "./unitlist"
 
 window.onload = () => {
 	applyThemeFromStorage()
@@ -37,6 +38,7 @@ window.onload = () => {
 		"/map": requireAuth(() => mapPage(body)),
 		"/login": () => loginPage(body),
 		"/resources": requireAuth(() => resourcesPage(body)),
+		"/units": requireAuth(() => unitListPage(body)),
 		"/building/:x/:y": (params: any) => {
 			const user = getUser()
 			if (!user) return navigate("/login")

--- a/server/ui/building.ts
+++ b/server/ui/building.ts
@@ -5,6 +5,9 @@ import {
 	onBuildQueueChange,
 	requestUpgradeAt,
 	getBuildQueue,
+	requestTrainAt,
+	getTrainQueue,
+	onTrainQueueChange,
 } from "./state"
 import { navigate } from "./router"
 
@@ -66,6 +69,38 @@ export const buildingPage = (body: HTMLElement, x: number, y: number) => {
 		upgrade.style.borderRadius = "6px"
 		upgrade.style.cursor = "pointer"
 
+		const trainSection = document.createElement("div")
+		trainSection.style.display = "none"
+		trainSection.style.paddingTop = "8px"
+		trainSection.style.borderTop = "1px solid var(--border)"
+		trainSection.style.marginTop = "8px"
+		const trainStatus = document.createElement("div")
+		const trainProgress = document.createElement("div")
+		trainProgress.style.height = "8px"
+		trainProgress.style.borderRadius = "999px"
+		trainProgress.style.background = "var(--track)"
+		trainProgress.style.overflow = "hidden"
+		const trainBar = document.createElement("div")
+		trainBar.style.height = "100%"
+		trainBar.style.width = "0%"
+		trainBar.style.background = "var(--accent)"
+		trainProgress.appendChild(trainBar)
+		const trainBtn = document.createElement("button")
+		trainBtn.textContent = "Train Soldier"
+		trainBtn.style.padding = "8px 12px"
+		trainBtn.style.border = "1px solid var(--border)"
+		trainBtn.style.background = "var(--button-bg)"
+		trainBtn.style.color = "var(--fg)"
+		trainBtn.style.borderRadius = "6px"
+		trainBtn.style.cursor = "pointer"
+		trainBtn.onclick = () => {
+			requestTrainAt(x, y, "soldier")
+			render()
+		}
+		trainSection.appendChild(trainStatus)
+		trainSection.appendChild(trainProgress)
+		trainSection.appendChild(trainBtn)
+
 		const render = () => {
 			const pb = getPlacedAt(x, y)
 			if (!pb) {
@@ -74,6 +109,7 @@ export const buildingPage = (body: HTMLElement, x: number, y: number) => {
 				statusRow.textContent = ""
 				upgrade.disabled = true
 				bar.style.width = "0%"
+				trainSection.style.display = "none"
 				return
 			}
 			nameRow.textContent = `Name: ${pb.building.name}`
@@ -99,6 +135,36 @@ export const buildingPage = (body: HTMLElement, x: number, y: number) => {
 				statusRow.textContent = "Idle"
 				upgrade.disabled = false
 			}
+
+			if (/barrack/i.test(pb.building.name)) {
+				trainSection.style.display = "grid"
+				const tq = getTrainQueue().find(
+					(i) =>
+						i.origin.x === x &&
+						i.origin.y === y &&
+						i.status === "training",
+				)
+				if (tq) {
+					const total = tq.finishAt - tq.startedAt
+					const elapsed = Math.min(
+						total,
+						Math.max(0, Date.now() - tq.startedAt),
+					)
+					const pct =
+						total > 0 ? Math.round((elapsed / total) * 100) : 0
+					trainBar.style.width = `${pct}%`
+					trainStatus.textContent = `Training (${fmtTimeLeft(
+						tq.finishAt - Date.now(),
+					)})`
+					trainBtn.disabled = true
+				} else {
+					trainBar.style.width = "0%"
+					trainStatus.textContent = "Idle"
+					trainBtn.disabled = false
+				}
+			} else {
+				trainSection.style.display = "none"
+			}
 		}
 
 		upgrade.onclick = () => {
@@ -111,12 +177,14 @@ export const buildingPage = (body: HTMLElement, x: number, y: number) => {
 		card.appendChild(statusRow)
 		card.appendChild(progress)
 		card.appendChild(upgrade)
+		card.appendChild(trainSection)
 
 		root.appendChild(header)
 		root.appendChild(card)
 
 		const unq = onBuildQueueChange(() => render())
 		const unb = onBuildingsChange(() => render())
+		const unt = onTrainQueueChange(() => render())
 		render()
 
 		window.addEventListener(
@@ -124,6 +192,7 @@ export const buildingPage = (body: HTMLElement, x: number, y: number) => {
 			() => {
 				unq()
 				unb()
+				unt()
 			},
 			{ once: true },
 		)

--- a/server/ui/nav.ts
+++ b/server/ui/nav.ts
@@ -2,7 +2,7 @@ import { navigate } from "./router"
 import { ThemeSwitch } from "./theme"
 import { getUser, clearToken, setUser } from "./auth"
 
-export type RouteKey = "overview" | "map" | "resources" | "login"
+export type RouteKey = "overview" | "map" | "resources" | "units" | "login"
 
 const NavLink = (label: string, path: string, active: boolean) => {
 	const a = document.createElement("button")
@@ -50,6 +50,7 @@ export const NavBar = (active: RouteKey) => {
 	if (current) {
 		center.appendChild(NavLink("Overview", "/", active === "overview"))
 		center.appendChild(NavLink("Map", "/map", active === "map"))
+		center.appendChild(NavLink("Units", "/units", active === "units"))
 		center.appendChild(
 			NavLink("Resources", "/resources", active === "resources"),
 		)

--- a/server/ui/state.ts
+++ b/server/ui/state.ts
@@ -1,4 +1,5 @@
 import type { Building } from "./buildinglist"
+import { findUnitSpec } from "./units-meta.ts"
 import { fetchWithAuth } from "./auth"
 
 export type BuildQueueItem = {
@@ -24,6 +25,7 @@ export type TrainQueueItem = {
 	startedAt: number
 	finishAt: number
 	status: "training" | "completed"
+	quantity: number
 }
 
 const et = new EventTarget()
@@ -168,8 +170,14 @@ export const addPlacedBuilding = (
 }
 
 export const getPlacedBuildings = () => state.buildings.slice()
-export const getPlacedAt = (x: number, y: number) =>
-	state.buildings.find((b) => b.origin.x === x && b.origin.y === y) || null
+export const getPlacedAt = (x: number, y: number) => {
+	const found = state.buildings.find((b) =>
+		b.building.shape.some(
+			(p) => b.origin.x + p.x === x && b.origin.y + p.y === y,
+		),
+	)
+	return found || null
+}
 
 const emitBuildings = () => {
 	et.dispatchEvent(
@@ -227,6 +235,8 @@ export const onUnitsChange = (cb: (items: Unit[]) => void) => {
 }
 
 const durationForUnit = (u: string) => {
+	const spec = findUnitSpec(u)
+	if (spec) return spec.trainTimeMs
 	if (/soldier/i.test(u)) return 4000
 	return 6000
 }
@@ -234,9 +244,11 @@ const durationForUnit = (u: string) => {
 export const enqueueTraining = (
 	unit: string,
 	origin: { x: number; y: number },
+	quantity = 1,
 ) => {
 	const now = Date.now()
-	const dur = durationForUnit(unit)
+	const q = Math.max(1, Math.floor(quantity))
+	const dur = durationForUnit(unit) * q
 	const item: TrainQueueItem = {
 		id: `${unit}-${origin.x}-${origin.y}-${now}`,
 		unit,
@@ -244,10 +256,31 @@ export const enqueueTraining = (
 		startedAt: now,
 		finishAt: now + dur,
 		status: "training",
+		quantity: q,
 	}
 	state.trainQueue.push(item)
-	// simple demo cost
-	state.resources.wood = Math.max(0, state.resources.wood - 50)
+	// Apply cost from metadata if available (simple demo: clamp to 0)
+	const spec = findUnitSpec(unit)
+	if (spec) {
+		if (spec.cost.wood)
+			state.resources.wood = Math.max(
+				0,
+				state.resources.wood - q * (spec.cost.wood ?? 0),
+			)
+		if (spec.cost.iron)
+			state.resources.iron = Math.max(
+				0,
+				state.resources.iron - q * (spec.cost.iron ?? 0),
+			)
+		if (spec.cost.food)
+			state.resources.food = Math.max(
+				0,
+				state.resources.food - q * (spec.cost.food ?? 0),
+			)
+	} else {
+		// fallback demo cost for unknown units
+		state.resources.wood = Math.max(0, state.resources.wood - 50 * q)
+	}
 	emitResources()
 	emitTrainQueue()
 
@@ -257,11 +290,13 @@ export const enqueueTraining = (
 			const it = state.trainQueue.find((q) => q.id === item.id)
 			if (it && it.status === "training") {
 				it.status = "completed"
-				state.units.push({
-					id: `unit-${Date.now()}`,
-					type: unit,
-					origin,
-				})
+				for (let i = 0; i < item.quantity; i++) {
+					state.units.push({
+						id: `unit-${Date.now()}-${i}`,
+						type: unit,
+						origin,
+					})
+				}
 				emitTrainQueue()
 				emitUnits()
 			}
@@ -272,12 +307,17 @@ export const enqueueTraining = (
 	return item
 }
 
-export const requestTrainAt = (x: number, y: number, unit: string) => {
+export const requestTrainAt = (
+	x: number,
+	y: number,
+	unit: string,
+	quantity = 1,
+) => {
 	const pb = getPlacedAt(x, y)
 	if (!pb) return null
 	const inProgress = state.trainQueue.find(
 		(q) => q.origin.x === x && q.origin.y === y && q.status === "training",
 	)
 	if (inProgress) return inProgress
-	return enqueueTraining(unit, pb.origin)
+	return enqueueTraining(unit, pb.origin, quantity)
 }

--- a/server/ui/unitlist.ts
+++ b/server/ui/unitlist.ts
@@ -1,1 +1,139 @@
-export class UnitList {}
+import { withLayout } from "./nav"
+import {
+	getTrainQueue,
+	onTrainQueueChange,
+	type TrainQueueItem,
+	getUnits,
+	onUnitsChange,
+	type Unit,
+} from "./state"
+
+const fmtTimeLeft = (ms: number) => {
+	if (ms <= 0) return "Done"
+	const s = Math.ceil(ms / 1000)
+	return `${s}s`
+}
+
+const renderQueueList = (container: HTMLElement, items: TrainQueueItem[]) => {
+	container.innerHTML = ""
+	if (!items.length) {
+		const empty = document.createElement("div")
+		empty.textContent = "No units training."
+		empty.style.color = "#bbb"
+		empty.style.fontSize = "13px"
+		empty.style.textAlign = "center"
+		empty.style.padding = "12px 0"
+		container.appendChild(empty)
+		return
+	}
+	const now = Date.now()
+	items
+		.slice()
+		.sort((a, b) => a.finishAt - b.finishAt)
+		.forEach((item) => {
+			const row = document.createElement("div")
+			row.style.display = "grid"
+			row.style.gridTemplateColumns = "1fr auto"
+			row.style.gap = "10px"
+			row.style.alignItems = "center"
+			row.style.padding = "8px"
+			row.style.border = "1px solid var(--border)"
+			row.style.borderRadius = "8px"
+			row.style.background = "var(--card)"
+			const title = document.createElement("div")
+			title.textContent = `${item.unit} @ (${item.origin.x},${item.origin.y})`
+			title.style.fontSize = "14px"
+			const total = item.finishAt - item.startedAt
+			const elapsed = Math.min(total, Math.max(0, now - item.startedAt))
+			const status = document.createElement("div")
+			status.style.fontSize = "12px"
+			status.style.color =
+				item.status === "completed" ? "var(--fg)" : "var(--muted)"
+			status.textContent =
+				item.status === "completed"
+					? "Completed"
+					: fmtTimeLeft(item.finishAt - now)
+			row.appendChild(title)
+			row.appendChild(status)
+			container.appendChild(row)
+		})
+}
+
+const renderUnits = (container: HTMLElement, units: Unit[]) => {
+	container.innerHTML = ""
+	if (!units.length) {
+		const empty = document.createElement("div")
+		empty.textContent = "No units available."
+		empty.style.color = "#bbb"
+		empty.style.fontSize = "13px"
+		empty.style.textAlign = "center"
+		empty.style.padding = "12px 0"
+		container.appendChild(empty)
+		return
+	}
+	units.forEach((u) => {
+		const row = document.createElement("div")
+		row.textContent = `${u.type} @ (${u.origin.x},${u.origin.y})`
+		row.style.padding = "4px 0"
+		container.appendChild(row)
+	})
+}
+
+export const unitListPage = (body: HTMLElement) => {
+	withLayout(body, "units", (root) => {
+		const grid = document.createElement("div")
+		grid.style.display = "grid"
+		grid.style.gridTemplateColumns = "1fr"
+		grid.style.gap = "16px"
+		const queueCard = document.createElement("div")
+		queueCard.style.border = "1px solid var(--border)"
+		queueCard.style.borderRadius = "10px"
+		queueCard.style.background = "var(--card)"
+		const qh = document.createElement("div")
+		qh.textContent = "Training Queue"
+		qh.style.padding = "12px 14px"
+		qh.style.fontWeight = "600"
+		qh.style.borderBottom = "1px solid var(--border)"
+		const qbody = document.createElement("div")
+		qbody.style.display = "grid"
+		qbody.style.gap = "8px"
+		qbody.style.padding = "12px"
+		queueCard.appendChild(qh)
+		queueCard.appendChild(qbody)
+		const unitCard = document.createElement("div")
+		unitCard.style.border = "1px solid var(--border)"
+		unitCard.style.borderRadius = "10px"
+		unitCard.style.background = "var(--card)"
+		const uh = document.createElement("div")
+		uh.textContent = "Units"
+		uh.style.padding = "12px 14px"
+		uh.style.fontWeight = "600"
+		uh.style.borderBottom = "1px solid var(--border)"
+		const ubody = document.createElement("div")
+		ubody.style.padding = "12px"
+		ubody.style.display = "grid"
+		ubody.style.gap = "4px"
+		unitCard.appendChild(uh)
+		unitCard.appendChild(ubody)
+		grid.appendChild(queueCard)
+		grid.appendChild(unitCard)
+		root.appendChild(grid)
+		renderQueueList(qbody, getTrainQueue())
+		renderUnits(ubody, getUnits())
+		const unq = onTrainQueueChange((items) => renderQueueList(qbody, items))
+		const unu = onUnitsChange((items) => renderUnits(ubody, items))
+		const interval = setInterval(
+			() => renderQueueList(qbody, getTrainQueue()),
+			250,
+		)
+		window.addEventListener(
+			"popstate",
+			() => {
+				unq()
+				unu()
+				clearInterval(interval)
+			},
+			{ once: true },
+		)
+	})
+}

--- a/server/ui/unitlist.ts
+++ b/server/ui/unitlist.ts
@@ -41,7 +41,9 @@ const renderQueueList = (container: HTMLElement, items: TrainQueueItem[]) => {
 			row.style.borderRadius = "8px"
 			row.style.background = "var(--card)"
 			const title = document.createElement("div")
-			title.textContent = `${item.unit} @ (${item.origin.x},${item.origin.y})`
+			const qty =
+				item.quantity && item.quantity > 1 ? ` x ${item.quantity}` : ""
+			title.textContent = `${item.unit}${qty} @ (${item.origin.x},${item.origin.y})`
 			title.style.fontSize = "14px"
 			const total = item.finishAt - item.startedAt
 			const elapsed = Math.min(total, Math.max(0, now - item.startedAt))
@@ -80,6 +82,7 @@ const renderUnits = (container: HTMLElement, units: Unit[]) => {
 }
 
 export const unitListPage = (body: HTMLElement) => {
+	console.log("rendering unit list page")
 	withLayout(body, "units", (root) => {
 		const grid = document.createElement("div")
 		grid.style.display = "grid"

--- a/server/ui/units-meta.ts
+++ b/server/ui/units-meta.ts
@@ -1,0 +1,29 @@
+export type UnitSpec = {
+	id: string
+	name: string
+	requiresBuilding: string[] // building names that can train this unit
+	trainTimeMs: number
+	cost: { wood?: number; iron?: number; food?: number }
+}
+
+export const UNIT_SPECS: UnitSpec[] = [
+	{
+		id: "soldier",
+		name: "Soldier",
+		requiresBuilding: ["Barrack"],
+		trainTimeMs: 4000,
+		cost: { wood: 50, food: 20 },
+	},
+]
+
+export const findUnitSpec = (id: string): UnitSpec | null => {
+	const spec = UNIT_SPECS.find((u) => u.id.toLowerCase() === id.toLowerCase())
+	return spec ?? null
+}
+
+export const trainablesForBuilding = (buildingName: string): UnitSpec[] => {
+	const name = buildingName.toLowerCase()
+	return UNIT_SPECS.filter((u) =>
+		u.requiresBuilding.some((b) => b.toLowerCase() === name),
+	)
+}


### PR DESCRIPTION
## Summary
- track unit training and unit roster in global state
- allow barracks to train soldiers via new training UI
- add Units page with navbar link to view training queue

## Testing
- `npm run typecheck` *(fails: Cannot find module 'bun:sqlite')*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a27bf0820083268d6d5d79add006a8