### PR TITLE
feat: persist buildings and units

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,3 @@
 After changes run npm run typecheck, npm run format, npm run lint, npm test
+also make sure tests are updated or new ones are added for new functionality
+the aim is to have high test coverage however some code like ui code might be hard to test.

--- a/server/db.migrations.test.ts
+++ b/server/db.migrations.test.ts
@@ -1,0 +1,13 @@
+import { describe, test } from "bun:test"
+import { Database } from "bun:sqlite"
+import { __test as dbTest } from "./db.ts"
+
+describe("migrations", () => {
+	test("runs without error and is idempotent", () => {
+		const db = new Database(":memory:")
+		// Run migrations; fail test if an exception is thrown
+		dbTest.migrate(db)
+		// Run again to ensure idempotency (no exceptions)
+		dbTest.migrate(db)
+	})
+})

--- a/server/db.ts
+++ b/server/db.ts
@@ -2,6 +2,22 @@ import { Database } from "bun:sqlite"
 
 export type Rates = { wood: number; iron: number; food: number }
 
+export type BuildingRecord = {
+	id: string
+	name: string
+	x: number
+	y: number
+	level: number
+	owner: string
+}
+
+export type UnitRecord = {
+	id: string
+	type: string
+	x: number
+	y: number
+}
+
 let _db: Database | null = null
 
 const init = () => {
@@ -38,32 +54,51 @@ function migrate(db: Database) {
 				// Schema
 				db.exec(`
           CREATE TABLE IF NOT EXISTS users (
-            username TEXT PRIMARY KEY,
+            id TEXT PRIMARY KEY,
+            username TEXT UNIQUE NOT NULL,
             password TEXT NOT NULL
           );
           CREATE TABLE IF NOT EXISTS rates (
-            username TEXT PRIMARY KEY,
+            userId TEXT PRIMARY KEY,
             wood REAL NOT NULL,
             iron REAL NOT NULL,
             food REAL NOT NULL,
-            FOREIGN KEY(username) REFERENCES users(username) ON DELETE CASCADE
+            FOREIGN KEY(userId) REFERENCES users(id) ON DELETE CASCADE
+          );
+          CREATE TABLE IF NOT EXISTS buildings (
+            id TEXT PRIMARY KEY,
+            userId TEXT NOT NULL,
+            name TEXT NOT NULL,
+            x INTEGER NOT NULL,
+            y INTEGER NOT NULL,
+            level INTEGER NOT NULL,
+            owner TEXT NOT NULL,
+            FOREIGN KEY(userId) REFERENCES users(id) ON DELETE CASCADE
+          );
+          CREATE TABLE IF NOT EXISTS units (
+            id TEXT PRIMARY KEY,
+            userId TEXT NOT NULL,
+            type TEXT NOT NULL,
+            x INTEGER NOT NULL,
+            y INTEGER NOT NULL,
+            FOREIGN KEY(userId) REFERENCES users(id) ON DELETE CASCADE
           );
         `)
 
 				// Seed demo data (idempotent)
 				const insertUser = db.query(
-					"INSERT OR IGNORE INTO users(username, password) VALUES(?, ?)",
+					"INSERT OR IGNORE INTO users(id, username, password) VALUES(?, ?, ?)",
 				)
-				insertUser.run("admin", "password")
-				insertUser.run("alice", "alicepass")
-				insertUser.run("bob", "bobpass")
+				insertUser.run("1", "admin", "password")
+				insertUser.run("2", "alice", "alicepass")
+				insertUser.run("3", "bob", "bobpass")
 
 				const insertRates = db.query(
-					"INSERT OR IGNORE INTO rates(username, wood, iron, food) VALUES(?, ?, ?, ?)",
+					"INSERT OR IGNORE INTO rates(userId, wood, iron, food) VALUES(?, ?, ?, ?)",
 				)
-				insertRates.run("admin", 1, 1, 1)
-				insertRates.run("alice", 2.0, 0.6, 1.2)
-				insertRates.run("bob", 0.7, 2.2, 1.5)
+				insertRates.run("1", 1, 1, 1)
+				insertRates.run("2", 2.0, 0.6, 1.2)
+				insertRates.run("3", 0.7, 2.2, 1.5)
 			},
 		},
 	]
@@ -85,44 +120,103 @@ function migrate(db: Database) {
 	}
 }
 
-const getUser = (
+const getUserByUsername = (
 	username: string,
-): { username: string; password: string } | null => {
+): { id: string; username: string; password: string } | null => {
 	const row = _db
-		.query("SELECT username, password FROM users WHERE username = ?")
-		.get(username) as { username: string; password: string } | undefined
+		.query("SELECT id, username, password FROM users WHERE username = ?")
+		.get(username) as
+		| { id: string; username: string; password: string }
+		| undefined
 	return row ?? null
 }
 
-const createUser = (username: string, password: string) => {
-	_db.query("INSERT INTO users(username, password) VALUES(?, ?)").run(
+const getUserById = (
+	id: string,
+): { id: string; username: string; password: string } | null => {
+	const row = _db
+		.query("SELECT id, username, password FROM users WHERE id = ?")
+		.get(id) as
+		| { id: string; username: string; password: string }
+		| undefined
+	return row ?? null
+}
+
+const createUser = (id: string, username: string, password: string) => {
+	_db.query("INSERT INTO users(id, username, password) VALUES(?, ?, ?)").run(
+		id,
 		username,
 		password,
 	)
 }
 
-const getUserRates = (username: string): Rates | null => {
+const getUserRates = (userId: string): Rates | null => {
 	const row = _db
-		.query("SELECT wood, iron, food FROM rates WHERE username = ?")
-		.get(username) as Rates | undefined
+		.query("SELECT wood, iron, food FROM rates WHERE userId = ?")
+		.get(userId) as Rates | undefined
 	return row ?? null
 }
 
-const upsertUserRates = (username: string, rates: Rates) => {
+const upsertUserRates = (userId: string, rates: Rates) => {
 	_db.query(
-		`INSERT INTO rates(username, wood, iron, food)
+		`INSERT INTO rates(userId, wood, iron, food)
      VALUES(?, ?, ?, ?)
-     ON CONFLICT(username) DO UPDATE SET
+     ON CONFLICT(userId) DO UPDATE SET
        wood = excluded.wood,
        iron = excluded.iron,
        food = excluded.food`,
-	).run(username, rates.wood, rates.iron, rates.food)
+	).run(userId, rates.wood, rates.iron, rates.food)
+}
+
+const getUserBuildings = (userId: string): BuildingRecord[] => {
+	return _db
+		.query(
+			"SELECT id, name, x, y, level, owner FROM buildings WHERE userId = ?",
+		)
+		.all(userId) as BuildingRecord[]
+}
+
+const upsertUserBuilding = (userId: string, b: BuildingRecord) => {
+	_db.query(
+		`INSERT INTO buildings(id, userId, name, x, y, level, owner)
+     VALUES(?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       name = excluded.name,
+       x = excluded.x,
+       y = excluded.y,
+       level = excluded.level,
+       owner = excluded.owner,
+       userId = excluded.userId`,
+	).run(b.id, userId, b.name, b.x, b.y, b.level, b.owner)
+}
+
+const getUserUnits = (userId: string): UnitRecord[] => {
+	return _db
+		.query("SELECT id, type, x, y FROM units WHERE userId = ?")
+		.all(userId) as UnitRecord[]
+}
+
+const upsertUserUnit = (userId: string, u: UnitRecord) => {
+	_db.query(
+		`INSERT INTO units(id, userId, type, x, y)
+     VALUES(?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       type = excluded.type,
+       x = excluded.x,
+       y = excluded.y,
+       userId = excluded.userId`,
+	).run(u.id, userId, u.type, u.x, u.y)
 }
 
 export const db = {
 	init,
 	createUser,
-	getUser,
+	getUserByUsername,
+	getUserById,
 	getUserRates,
 	upsertUserRates,
+	getUserBuildings,
+	upsertUserBuilding,
+	getUserUnits,
+	upsertUserUnit,
 }

--- a/server/db.ts
+++ b/server/db.ts
@@ -29,7 +29,7 @@ const init = () => {
 	return _db
 }
 
-function migrate(db: Database) {
+function migrate(db: Database, logger: (msg: string) => void = console.log) {
 	db.exec(
 		`CREATE TABLE IF NOT EXISTS migrations (
         id INTEGER PRIMARY KEY,
@@ -113,8 +113,14 @@ function migrate(db: Database) {
 				m.name,
 			)
 			db.exec("COMMIT")
+			logger(`Migration ${m.id} (${m.name}): success`)
 		} catch (e) {
 			db.exec("ROLLBACK")
+			logger(
+				`Migration ${m.id} (${m.name}): error: ${
+					e instanceof Error ? e.message : String(e)
+				}`,
+			)
 			throw e
 		}
 	}
@@ -219,4 +225,9 @@ export const db = {
 	upsertUserBuilding,
 	getUserUnits,
 	upsertUserUnit,
+}
+
+// Test-only helper to run migrations with a provided logger
+export const __test = {
+	migrate,
 }

--- a/server/ui/app.ts
+++ b/server/ui/app.ts
@@ -5,14 +5,18 @@ import { loginPage } from "./login"
 import { resourcesPage } from "./resources"
 import { applyThemeFromStorage } from "./theme"
 import { refreshUser, getUser } from "./auth"
-import { loadResourceRates } from "./state"
+import { loadResourceRates, loadBuildings, loadUnits } from "./state"
 import { buildingPage } from "./building"
 import { unitListPage } from "./unitlist"
 
 window.onload = () => {
 	applyThemeFromStorage()
 	refreshUser()
-		.then(() => loadResourceRates())
+		.then(() => {
+			loadResourceRates()
+			loadBuildings()
+			loadUnits()
+		})
 		.catch(() => {})
 	const body = document.querySelector("body")
 	if (!body) {

--- a/server/ui/auth.ts
+++ b/server/ui/auth.ts
@@ -1,7 +1,7 @@
 const TOKEN_KEY = "df_token"
 const USER_KEY = "df_user"
 
-export type User = { username: string }
+export type User = { id: string; username: string }
 
 export const getToken = () => localStorage.getItem(TOKEN_KEY)
 export const setToken = (t: string) => localStorage.setItem(TOKEN_KEY, t)


### PR DESCRIPTION
## Summary
- store buildings and units in SQLite with new tables and helpers keyed by userId
- expose REST endpoints to manage buildings and units
- sync frontend state with backend for buildings and unit training

## Testing
- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2a82793c08326be9e39457298aea3